### PR TITLE
Implement custom Liquid tags

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -3,6 +3,59 @@ const vscode = require('vscode');
 const liquid = require('liquidjs');
 const liquidEngine = new liquid();
 
+// register custom Liquid tags used in templates
+registerCustomTags(liquidEngine);
+
+function registerCustomTags(engine) {
+    // optional tag simply renders its inner content
+    engine.registerTag('optional', {
+        parse(tagToken, remainTokens) {
+            this.templates = [];
+            const stream = this.liquid.parser.parseStream(remainTokens)
+                .on('tag:endoptional', () => stream.stop())
+                .on('template', tpl => this.templates.push(tpl))
+                .on('end', () => { throw new Error('optional tag not closed'); });
+            stream.start();
+        },
+        render(ctx) {
+            return this.liquid.renderer.renderTemplates(this.templates, ctx);
+        }
+    });
+
+    // editor tag renders the default text between editor/endeditor
+    engine.registerTag('editor', {
+        parse(tagToken, remainTokens) {
+            this.templates = [];
+            const stream = this.liquid.parser.parseStream(remainTokens)
+                .on('tag:endeditor', () => stream.stop())
+                .on('template', tpl => this.templates.push(tpl))
+                .on('end', () => { throw new Error('editor tag not closed'); });
+            stream.start();
+        },
+        render(ctx) {
+            return this.liquid.renderer.renderTemplates(this.templates, ctx);
+        }
+    });
+
+    // choice tag supports multiple blocks separated by 'or'.
+    // The preview simply renders the first block.
+    engine.registerTag('choice', {
+        parse(tagToken, remainTokens) {
+            this.parts = [[]];
+            const stream = this.liquid.parser.parseStream(remainTokens)
+                .on('tag:or', () => this.parts.push([]))
+                .on('tag:endchoice', () => stream.stop())
+                .on('template', tpl => this.parts[this.parts.length - 1].push(tpl))
+                .on('end', () => { throw new Error('choice tag not closed'); });
+            stream.start();
+            this.templates = this.parts[0];
+        },
+        render(ctx) {
+            return this.liquid.renderer.renderTemplates(this.templates, ctx);
+        }
+    });
+}
+
 function activate(context) {
     let templateStatusBarItem;
     let dataStatusBarItem;


### PR DESCRIPTION
## Summary
- register custom tags `editor`, `optional` and `choice` for Liquid engine
- render the first choice by default

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68403c1c1344832db66adb9a35cf7dd1